### PR TITLE
Created Header

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,9 @@
 
 <head>
   <meta charset="UTF-8" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Jersey+25&display=swap" rel="stylesheet">
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FlashWhizz</title>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
 import { Label } from "@/components/ui/Label"
+import Header from "@/components/Header";
 function App() {
 
   return (
     <>
+      <Header />
       <div className="h-screen flex items-center justify-center">
         <Label>FlashWhizz</Label>
       </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,41 @@
+import SearchIcon from "./icons/search";
+import CircleUserRoundIcon from "./icons/circle-user-round";
+
+const Header: React.FC = () => {
+  return (
+    <header id="header" className="flex items-center justify-between px-4 py-2">
+      <h1
+        className="jersey-25-regular"
+        style={{ fontSize: '6rem', color: 'var(--palette-1)', WebkitTextStrokeWidth: '0.15rem', WebkitTextStrokeColor: 'black' }}>
+          FlashWhizz
+      </h1>
+      <div id="navigation" className="flex items-center gap-4">
+        <div id="search" className="relative min-w-50">
+          <input
+            type="text"
+            placeholder=""
+            className="h-60px w-full rounded-full bg-white px-4 py-2 pr-12 text-black focus:outline-none focus:ring-1 focus:ring-primary"
+            style={{border: 'solid', borderWidth: '5px', borderColor: 'var(--palette-2)'}}
+          />
+          <input type="button" value="" />
+          <SearchIcon
+            size={40}
+            color="var(--palette-4)"
+            strokeWidth={2}
+            className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer"
+          />
+        </div>
+        <CircleUserRoundIcon
+          size={96}
+          color="var(--palette-4)"
+          strokeWidth={1.5}
+          className="cursor-pointer"
+          />
+      </div>
+      
+    </header>
+  );
+};
+
+export default Header;
+

--- a/frontend/src/components/icons/circle-user-round.tsx
+++ b/frontend/src/components/icons/circle-user-round.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+const CircleUserRoundIcon = ({
+  size = 24,
+  color = '#f314ff',
+  strokeWidth = 2,
+  background = 'transparent',
+  opacity = 1,
+  rotation = 0,
+  shadow = 0,
+  flipHorizontal = false,
+  flipVertical = false,
+  padding = 0,
+  className,
+  ...props
+}) => {
+  const transforms = [];
+  if (rotation !== 0) transforms.push(`rotate(${rotation}deg)`);
+  if (flipHorizontal) transforms.push('scaleX(-1)');
+  if (flipVertical) transforms.push('scaleY(-1)');
+
+  const viewBoxSize = 24 + (padding * 2);
+  const viewBoxOffset = -padding;
+  const viewBox = `${viewBoxOffset} ${viewBoxOffset} ${viewBoxSize} ${viewBoxSize}`;
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox={viewBox}
+      width={size}
+      height={size}
+      fill="none"
+      stroke={color}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+      style={{
+        opacity,
+        transform: transforms.join(' ') || undefined,
+        filter: shadow > 0 ? `drop-shadow(0 ${shadow}px ${shadow * 2}px rgba(0,0,0,0.3))` : undefined,
+        backgroundColor: background !== 'transparent' ? background : undefined
+      }}
+    >
+      <g fill="none" stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth={strokeWidth}>
+        <path d="M18 20a6 6 0 0 0-12 0" />
+        <circle cx="12" cy="10" r="4" />
+        <circle cx="12" cy="12" r="10" />
+      </g>
+    </svg>
+  );
+};
+
+export default CircleUserRoundIcon;

--- a/frontend/src/components/icons/search.tsx
+++ b/frontend/src/components/icons/search.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+const SearchIcon = ({
+  size = 24,
+  color = '#000000',
+  strokeWidth = 2,
+  background = 'transparent',
+  opacity = 1,
+  rotation = 0,
+  shadow = 0,
+  flipHorizontal = false,
+  flipVertical = false,
+  padding = 0,
+  className,
+  ...props
+}) => {
+  const transforms = [];
+  if (rotation !== 0) transforms.push(`rotate(${rotation}deg)`);
+  if (flipHorizontal) transforms.push('scaleX(-1)');
+  if (flipVertical) transforms.push('scaleY(-1)');
+
+  const viewBoxSize = 24 + (padding * 2);
+  const viewBoxOffset = -padding;
+  const viewBox = `${viewBoxOffset} ${viewBoxOffset} ${viewBoxSize} ${viewBoxSize}`;
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox={viewBox}
+      width={size}
+      height={size}
+      fill="none"
+      stroke={color}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+      style={{
+        opacity,
+        transform: transforms.join(' ') || undefined,
+        filter: shadow > 0 ? `drop-shadow(0 ${shadow}px ${shadow * 2}px rgba(0,0,0,0.3))` : undefined,
+        backgroundColor: background !== 'transparent' ? background : undefined
+      }}
+    >
+      <g fill="none" stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth={strokeWidth}>
+        <path d="m21 21l-4.34-4.34" />
+        <circle cx="11" cy="11" r="8" />
+      </g>
+    </svg>
+  );
+};
+
+export default SearchIcon;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -38,6 +38,11 @@
     --sidebar-accent-foreground: oklch(0.205 0 0);
     --sidebar-border: oklch(0.922 0 0);
     --sidebar-ring: oklch(0.708 0 0);
+    --palette-1: #1B998B;
+    --palette-2: #3C493F;
+    --palette-3: #7E52A0;
+    --palette-4: #E0B0D5;
+    --palette-5: #ECFEE8;
 }
 
 .dark {
@@ -126,4 +131,18 @@
   html {
     @apply font-sans;
     }
+}
+
+.jersey-25-regular {
+  font-family: "Jersey 25", sans-serif;
+  font-weight: 400;
+  font-style: normal;
+}
+
+header {
+  display: flex;
+  height: 9rem;
+  background-color: var(--palette-3);
+  stroke-width: 3px;
+  padding-left: 40px;
 }


### PR DESCRIPTION
We use some icons from lucide-react in the Figma - I manually added the two we use, but we may want to just install the package

Jersey-25 font is currently a css class and is fetched online, but we can also easily make it the default font for the entire app and/or serve the font ourselves if wanted.

Some styling is in the style sheet, some is in-line in the header. Some is Tailwind. Will make this all more consistent later.